### PR TITLE
Replace #before_filter with #before_action (Rails 5)

### DIFF
--- a/lean_stamper.gemspec
+++ b/lean_stamper.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "lean_stamper"
   gem.require_paths = ["lib"]
-  gem.version       = "0.0.4"
+  gem.version       = "0.0.5"
 end

--- a/lib/userstamp.rb
+++ b/lib/userstamp.rb
@@ -14,8 +14,8 @@ module Ddb
     module Userstamp
       def self.included(base) # :nodoc:
         base.send           :include, InstanceMethods
-        base.before_filter  :set_stamper
-        base.after_filter   :reset_stamper
+        base.before_action  :set_stamper
+        base.after_action   :reset_stamper
       end
 
       module InstanceMethods


### PR DESCRIPTION
Removes deprecated `#before_filter`, for Pistachio upgrade to Rails 5: https://github.com/alphasights/pistachio/pull/6029.

`DEPRECATION WARNING: after_filter is deprecated and will be removed in Rails 5.1. Use after_action instead. (called from include at /pistachio/app/controllers/internal_controller.rb:5)`